### PR TITLE
Support pasting

### DIFF
--- a/blots/nested.js
+++ b/blots/nested.js
@@ -68,6 +68,14 @@ class Nested extends Container {
     return { [this.statics.blotName]: attributes }
   }
 
+  static formats(domNode) {
+    let attributes = {}
+    for(let i = 0; i < domNode.attributes.length; i++) {
+      attributes[domNode.attributes[i].name] = domNode.attributes[i].value
+    }
+    return attributes
+  }
+
   optimize() {
     super.optimize();
 


### PR DESCRIPTION
FormatAt block was preventing processing of nested containers. It is
not needed anymore since we already implemented container nesting
behaviour in core/quill.js.